### PR TITLE
added code to replace '.' with '|' and fixed line break issue

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -4,21 +4,31 @@ function TRANSLATION_HANDLER(e) {
       return;
 
     let { value } = e.target;
-    let splittedText = value.split(" ");
-    let recentText = splittedText[splittedText.length - 1];
-    if (!recentText) return;
-    if (recentText === "," || recentText === "|") return;
-    let translatedTextArray = [...splittedText];
-    translatedTextArray.pop();
+    let lines = value.split("\n");
+    let lastLine = lines[lines.length - 1];
 
-    let fetchUrl = `https://www.google.com/inputtools/request?text=${recentText}&ime=transliteration_en_ne&num=1`;
+    let words = lastLine.split(" ");
+    let recentWord = words[words.length - 1];
+
+    if (!recentWord || recentWord === "," || recentWord === "|") {
+      return;
+    }
+
+    let fetchUrl = `https://www.google.com/inputtools/request?text=${recentWord}&ime=transliteration_en_ne&num=1`;
 
     fetch(fetchUrl)
       .then((res) => res.json())
       .then((res) => {
-        let translatedText = res[1][0][1][0];
-        translatedTextArray.push(translatedText);
-        e.target.value = translatedTextArray.join(" ") + " ";
+        let translatedWord = res[1][0][1][0];
+
+        // Replace "." with "|"
+        translatedWord = translatedWord.endsWith('.') ? translatedWord.replace('.', ' |') : translatedWord;
+
+        words[words.length - 1] = translatedWord;
+        lastLine = words.join(" ");
+
+        lines[lines.length - 1] = lastLine;
+        e.target.value = lines.join("\n") + " ";
       });
   }
 }


### PR DESCRIPTION
- Added code to replace "." with "|" when translating,
- Fixed issue where line breaks were being replaced on previous line after translation.