### PR TITLE
Commands support 

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Type Nepali",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Type in Nepali.",
   "icons": {
     "16": "img/icons/icon-16.png",
@@ -13,6 +13,7 @@
     "default_popup": "popup.html"
   },
   "permissions": ["tabs", "storage", "activeTab"],
+  "background": {"service_worker": "scripts/background.js"},
   "content_scripts": [
     {
       "js": ["scripts/content.js"],
@@ -20,6 +21,13 @@
       "run_at": "document_start"
     }
   ],
-
-  "host_permissions": ["<all_urls>"]
+  "host_permissions": ["<all_urls>"],
+  "commands":{
+    "Turn nepali typing on/off":{
+        "suggested_key": {"default": "Ctrl+O",
+                            "mac":"MacCtrl+O"
+    },
+        "description": "Turn Nepali typing on/off without opening the extension popup"
+    }
+  }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,7 @@
   ],
   "host_permissions": ["<all_urls>"],
   "commands":{
-    "Turn nepali typing on/off":{
+    "turn-nepali-typing-on/off":{
         "suggested_key": {"default": "Ctrl+O",
                             "mac":"MacCtrl+O"
     },

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -1,0 +1,34 @@
+// Check for keyboard shortcuts and change storage value if appropriate command
+chrome.commands.onCommand.addListener(
+    (command)=> {
+                if (command == "turn-nepali-typing-on/off"){
+                        chrome.storage.sync.get(["translateText"]).then((result) => {
+                        let valueToSwitchTo = (result.translateText) ? false : true
+                        TOGGLE_TRANSLATE_VALUE(valueToSwitchTo);
+                });
+        }
+    }
+)
+
+chrome.runtime.onMessage.addListener((message) => {
+        TOGGLE_TRANSLATE_VALUE(message.toggle_value)
+});
+
+function TOGGLE_TRANSLATE_VALUE(boolean) {
+        console.log("The value is now", boolean);
+        chrome.storage.sync.set({
+          translateText: boolean,
+        });
+        chrome.tabs.query({}, function (tabs) {
+          tabs.forEach(async (tab) => {
+            // if the tab is a chrome url return
+            const pattern = /^chrome\:\/\/.*/;
+            if (pattern.test(tab.url)) return;
+            console.log(tab);
+      
+            await chrome.tabs.sendMessage(tab.id, {
+              translate: boolean,
+            });
+          });
+        });
+      }

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -9,30 +9,12 @@ chrome.storage.sync.get(["translateText"]).then((obj) => {
 btn.addEventListener("click", function () {
   let btnTxtContent = btn.textContent;
   if (btnTxtContent === "On") {
-    TOGGLE_TRANSLATE_VALUE(false);
+    chrome.runtime.sendMessage({toggle_value: false});
     btn.textContent = "Off";
     btn.classList.add("off");
   } else {
-    TOGGLE_TRANSLATE_VALUE(true);
+    chrome.runtime.sendMessage({toggle_value: true});
     btn.textContent = "On";
     btn.classList.remove("off");
   }
 });
-
-function TOGGLE_TRANSLATE_VALUE(boolean) {
-  chrome.storage.sync.set({
-    translateText: boolean,
-  });
-  chrome.tabs.query({}, function (tabs) {
-    tabs.forEach(async (tab) => {
-      // if the tab is a chrome url return
-      const pattern = /^chrome\:\/\/.*/;
-      if (pattern.test(tab.url)) return;
-      console.log(tab);
-
-      await chrome.tabs.sendMessage(tab.id, {
-        translate: boolean,
-      });
-    });
-  });
-}

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -1,3 +1,11 @@
+// Connect to background.js to notify popup is open
+chrome.runtime.connect({name:"popup"});
+
+// Handle keyboard shortcuts when popup is open by simulating as if the user pressed the button
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.message == "button-press") BUTTON_PRESSED();
+});
+
 let btn = document.querySelector("button");
 chrome.storage.sync.get(["translateText"]).then((obj) => {
   btn.textContent = obj.translateText ? "On" : "Off";
@@ -6,15 +14,17 @@ chrome.storage.sync.get(["translateText"]).then((obj) => {
   }
 });
 
-btn.addEventListener("click", function () {
+btn.addEventListener("click", BUTTON_PRESSED);
+
+function BUTTON_PRESSED() {
   let btnTxtContent = btn.textContent;
   if (btnTxtContent === "On") {
-    chrome.runtime.sendMessage({toggle_value: false});
+    chrome.runtime.sendMessage({toggle_value: false, message: "toggle-value"});
     btn.textContent = "Off";
     btn.classList.add("off");
   } else {
-    chrome.runtime.sendMessage({toggle_value: true});
+    chrome.runtime.sendMessage({toggle_value: true, message: "toggle-value"});
     btn.textContent = "On";
     btn.classList.remove("off");
   }
-});
+}


### PR DESCRIPTION
Fixes #6 

* Add keyboard shortcuts to turn on/off Nepali-typing without opening the extension and clicking the button
* A background service worker has been added since the shortcut would need to work whether or not the extension would be open
* To do this, the function `TOGGLE_TRANSLATE_VALUE` from `popup.js` has been moved to `background.js`.
* Reflect changes in on/off value of button in the popup if keyboard shortcut used while the popup is open